### PR TITLE
fix: mark context as dirty and ensure tracking in clear_context_by_name

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -692,11 +692,18 @@ impl AppState {
             name: context_name.to_string(),
             messages: Vec::new(),
             created_at: now_timestamp(),
-            updated_at: 0,
+            updated_at: now_timestamp(),  // Mark as updated (like clear_context does)
             summary: String::new(),
         };
 
         self.save_context(&new_context)?;
+
+        // Ensure the context is tracked in state (like clear_context does via save_current_context)
+        if !self.state.contexts.contains(&new_context.name) {
+            let mut new_state = self.state.clone();
+            new_state.contexts.push(new_context.name.clone());
+            new_state.save(&self.state_path)?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
This PR addresses issues #21 and #22 by fixing inconsistencies between clear_context and clear_context_by_name functions.

**Changes:**
- Set updated_at timestamp when clearing context by name (like clear_context does)
- Ensure context is tracked in state after clearing (like clear_context does via save_current_context)

**Details:**
- Fixed clear_context_by_name to mark context as 'dirty' by setting updated_at to current timestamp
- Added logic to ensure cleared context is properly tracked in application state
- This makes clear_context_by_name behave consistently with clear_context

Fixes #22
Fixes #21