### PR TITLE
add self-destructing contexts for test cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Hook data passed via `CHIBI_HOOK` and `CHIBI_HOOK_DATA` env vars.
 ~/.chibi/
 ├── config.toml              # Required: api_key, model, context_window_limit, warn_threshold_percent
 ├── models.toml              # Model aliases, context windows, API params
-├── state.json               # Current context name
+├── state.json               # Current context name, context metadata (activity, auto-destroy)
 ├── prompts/
 │   ├── chibi.md            # Default system prompt
 │   ├── reflection.md       # LLM's persistent memory
@@ -227,3 +227,21 @@ partition_max_entries = 500         # More aggressive for busy contexts
 partition_max_tokens = 50000        # Lower token threshold
 bytes_per_token = 4                 # Less conservative for English-only content
 ```
+
+### Context Auto-Destroy (Debug Feature)
+
+Contexts track activity and can be marked for automatic destruction. This is primarily for test cleanup.
+
+**state.json context entry fields:**
+- `last_activity_at` - Updated every time chibi runs with the context (always on)
+- `destroy_at` - Absolute timestamp; context destroyed when `now > destroy_at` (0 = disabled)
+- `destroy_after_seconds_inactive` - Inactivity timeout in seconds (0 = disabled)
+
+**Debug flags to set destroy settings:**
+```bash
+chibi --debug destroy_at=1234567890 -c test-ctx      # Destroy at timestamp
+chibi --debug destroy_after_seconds_inactive=60 -c test-ctx  # Destroy after 60s inactivity
+```
+
+Auto-destroy runs at every chibi invocation, destroying non-current contexts that meet criteria.
+Used in tests to avoid manual cleanup of test contexts.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -126,11 +126,37 @@ Use `-n home` to inspect the resolved path.
 
 | Flag | Description |
 |------|-------------|
-| `--debug <KEY>` | Enable debug logging: `request-log`, `response-meta`, `all` |
+| `--debug <KEY>` | Enable debug features (see below) |
+
+### Debug Keys
+
+| Key | Description |
+|-----|-------------|
+| `request-log` | Log full API request bodies to `requests.jsonl` |
+| `response-meta` | Log response metadata/usage stats to `response_meta.jsonl` |
+| `all` | Enable all logging features above |
+| `destroy_at=<TIMESTAMP>` | Set auto-destroy timestamp on current context |
+| `destroy_after_seconds_inactive=<SECS>` | Set inactivity timeout on current context |
+
+### Debug Logging
 
 Debug output is written to files in the context directory:
 - `requests.jsonl` - Full API request bodies (with `request-log` or `all`)
 - `response_meta.jsonl` - Response metadata, usage stats, model info (with `response-meta` or `all`)
+
+### Auto-Destroy (Test Cleanup)
+
+Contexts can be marked for automatic destruction, primarily for test cleanup:
+
+```bash
+# Destroy context after 60 seconds of inactivity
+chibi --debug destroy_after_seconds_inactive=60 -c test-ctx
+
+# Destroy context at a specific timestamp
+chibi --debug destroy_at=1234567890 -c test-ctx
+```
+
+Auto-destroy runs automatically at every chibi invocation. It checks all non-current contexts and destroys those that meet the criteria. This prevents test contexts from accumulating.
 
 ## Flag Behavior
 

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -132,6 +132,36 @@ The `-L` flag shows lock status:
 
 If a process crashes, its lock becomes stale. Chibi automatically cleans up stale locks and acquires a new one.
 
+## Activity Tracking & Auto-Destroy
+
+Chibi tracks when each context was last used. This enables automatic cleanup of test contexts.
+
+### Activity Tracking
+
+Every time chibi runs with a context, it updates the `last_activity_at` timestamp in `state.json`. This happens automatically during normal usage.
+
+### Auto-Destroy (Debug Feature)
+
+Contexts can be marked for automatic destruction using `--debug` flags. This is primarily for test cleanup:
+
+```bash
+# Create a context that auto-destroys after 60 seconds of inactivity
+chibi --debug destroy_after_seconds_inactive=60 -c test-context
+
+# Create a context that auto-destroys at a specific timestamp
+chibi --debug destroy_at=1737820800 -c ephemeral-context
+```
+
+**How it works:**
+- Auto-destroy checks run at the start of every chibi invocation
+- Only non-current contexts are eligible for destruction
+- A context is destroyed if:
+  - `destroy_at >= 1` and current time > `destroy_at`, OR
+  - `destroy_after_seconds_inactive >= 1` and current time > `last_activity_at + destroy_after_seconds_inactive`
+- Values of 0 disable the respective feature (default)
+
+**Use case:** Integration tests can create contexts with short inactivity timeouts. Subsequent normal chibi usage automatically cleans them up.
+
 ## Per-Context System Prompts
 
 Each context can have its own system prompt:

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -7,6 +7,14 @@
 //! require API keys and network access. Those behaviors are tested via unit
 //! tests in cli.rs which verify the argument parsing produces the correct
 //! Cli struct.
+//!
+//! ## Context Cleanup
+//!
+//! Tests that create contexts use `--debug destroy_after_seconds_inactive=1`
+//! to mark them for automatic cleanup. This ensures test contexts don't
+//! accumulate in the user's ~/.chibi directory. The auto-destroy feature
+//! runs at every chibi invocation, so subsequent normal usage cleans up
+//! these test contexts automatically.
 
 use std::fs;
 use std::process::Command;
@@ -222,8 +230,15 @@ fn integration_attached_arg_form() {
 fn integration_switch_to_new_context() {
     // -c new should switch to a new auto-generated context
     // Since -c alone doesn't produce output without prompt, use -l to see the context
+    // Use --debug destroy_after_seconds_inactive=1 so the context is auto-cleaned
     let output = Command::new(env!("CARGO_BIN_EXE_chibi"))
-        .args(["-c", "new", "-l"])
+        .args([
+            "--debug",
+            "destroy_after_seconds_inactive=1",
+            "-c",
+            "new",
+            "-l",
+        ])
         .output()
         .expect("failed to run chibi");
 
@@ -265,8 +280,15 @@ fn integration_switch_to_new_context() {
 /// Test that -c new:prefix creates a prefixed timestamped context name
 #[test]
 fn integration_switch_to_new_context_with_prefix() {
+    // Use --debug destroy_after_seconds_inactive=1 so the context is auto-cleaned
     let output = Command::new(env!("CARGO_BIN_EXE_chibi"))
-        .args(["-c", "new:myprefix", "-l"])
+        .args([
+            "--debug",
+            "destroy_after_seconds_inactive=1",
+            "-c",
+            "new:myprefix",
+            "-l",
+        ])
         .output()
         .expect("failed to run chibi");
 
@@ -306,8 +328,15 @@ fn integration_new_context_empty_prefix_error() {
 /// Test transient context with -C new
 #[test]
 fn integration_transient_new_context() {
+    // Use --debug destroy_after_seconds_inactive=1 so the context is auto-cleaned
     let output = Command::new(env!("CARGO_BIN_EXE_chibi"))
-        .args(["-C", "new", "-l"])
+        .args([
+            "--debug",
+            "destroy_after_seconds_inactive=1",
+            "-C",
+            "new",
+            "-l",
+        ])
         .output()
         .expect("failed to run chibi");
 
@@ -414,8 +443,13 @@ fn integration_json_config_mode_context_switch() {
     use std::io::Write;
     use std::process::Stdio;
 
+    // Use --debug destroy_after_seconds_inactive=1 so the context is auto-cleaned
     let mut child = Command::new(env!("CARGO_BIN_EXE_chibi"))
-        .arg("--json-config")
+        .args([
+            "--debug",
+            "destroy_after_seconds_inactive=1",
+            "--json-config",
+        ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
(locked away behind --debug flag for now)

contexts now track last_activity_at (updated on every chibi run) and can be marked for automatic destruction via --debug flags:

  --debug destroy_after_seconds_inactive=<SECONDS>
  --debug destroy_at=<TIMESTAMP>

auto-destroy runs at every chibi invocation, checking all non-current contexts and destroying those that meet criteria. values of 0 disable the feaure (and that's the default).

this enables integration tests that don't create temporary home directories to create contexts that get cleaned up automatically with normal chibi usage.

if it works well, it's a good addition to the standard base functionality, as a kind "incognito mode" chibi.

changes:
- Add last_activity_at, destroy_after_seconds_inactive, destroy_at fields to ContextEntry in state.json (with serde defaults for compatibility)
- Add DebugKey::DestroyAt(u64) and DebugKey::DestroyAfterSecondsInactive(u64)
- Add AppState::touch_context_with_destroy_settings() and AppState::auto_destroy_expired_contexts()
- Update integration tests to use --debug destroy_after_seconds_inactive=1
- Document feature in CLAUDE.md, docs/cli-reference.md, docs/contexts.md

happy fmt+clippy