### PR TITLE
refactor system prompt storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Hook data passed via `CHIBI_HOOK` and `CHIBI_HOOK_DATA` env vars.
 ~/.chibi/
 ├── config.toml              # Required: api_key, model, context_window_limit, warn_threshold_percent
 ├── models.toml              # Model aliases, context windows, API params
-├── state.json               # Current context name, context metadata (activity, auto-destroy)
+├── state.json               # Current context name, context list (created_at, activity, auto-destroy)
 ├── prompts/
 │   ├── chibi.md            # Default system prompt
 │   ├── reflection.md       # LLM's persistent memory
@@ -124,7 +124,7 @@ Hook data passed via `CHIBI_HOOK` and `CHIBI_HOOK_DATA` env vars.
     │       ├── <ts>-<ts>.jsonl
     │       └── <ts>-<ts>.bloom
     ├── transcript.md       # Human-readable archive
-    ├── context_meta.json   # Metadata (created_at)
+    ├── context_meta.json   # Metadata (system_prompt_md_mtime, last_combined_prompt)
     ├── local.toml          # Per-context config overrides
     ├── summary.md          # Conversation summary
     ├── todos.md            # Current todos

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -234,6 +234,11 @@ async fn send_prompt_with_depth(
         }
     }
 
+    // Store combined prompt in context_meta for API request reconstruction
+    if !full_system_prompt.is_empty() {
+        app.save_combined_system_prompt(&context.name, &full_system_prompt)?;
+    }
+
     let mut messages: Vec<serde_json::Value> = if !full_system_prompt.is_empty() {
         vec![serde_json::json!({
             "role": "system",


### PR DESCRIPTION
the single source of truth for the raw system prompt is system_prompt.md the combined system prompt (with plugin hook injected data etc) is never stored anywhere. this is inconvenient.

1. removed dead data (system_prompt_hash)
  - removed compute_system_prompt_hash() function
  - removed hash field from EntryMetadata struct
  - updated all tests that referenced hash
2. simplified ContextMeta structure
  - removed created_at field (state.json is now single source of truth)
  - added system_prompt_md_mtime: Option<u64> - tracks file mtime for external change detection
  - added last_combined_prompt: Option<String> - stores full prompt sent to API
3. removed system prompt from context.jsonl
  - context now has structure: [anchor, entries...] instead of [anchor, system_prompt, entries...]
  - removed ENTRY_TYPE_SYSTEM_PROMPT constant (no longer used)
  - updated rebuild_context_from_transcript() to not include system prompt entry
4. added system prompt mtime change detection
  - check_system_prompt_mtime_change() runs on context load
  - detects if system_prompt.md was edited externally
  - if changed: logs full raw prompt to transcript, updates mtime, marks dirty
5. updated transcript logging
  - system_prompt_changed entries now contain full raw prompt content (not just "System prompt updated")
6. store combined prompt on API request
  - save_combined_system_prompt() called in send_prompt() after building full prompt
  - allows reconstructing the exact API request from context.jsonl + context_meta.json
7. CLAUDE.md