### PR TITLE
fix self-destructing contexts not actually going away

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,9 @@ mod state;
 mod tools;
 
 use cli::Inspectable;
-use context::{Context, ENTRY_TYPE_MESSAGE, ENTRY_TYPE_TOOL_CALL, ENTRY_TYPE_TOOL_RESULT};
+use context::{
+    Context, ContextEntry, ENTRY_TYPE_MESSAGE, ENTRY_TYPE_TOOL_CALL, ENTRY_TYPE_TOOL_RESULT,
+};
 use input::{ChibiInput, Command, ContextSelection, UsernameOverride};
 use output::OutputHandler;
 use state::AppState;
@@ -294,6 +296,20 @@ async fn execute_from_input(
             let actual_name = resolve_context_name(app, name)?;
             let prev_context = app.state.current_context.clone();
             app.state.switch_context(actual_name)?;
+
+            // Ensure ContextEntry exists in state.contexts before proceeding
+            let current_ctx_name = app.state.current_context.clone();
+            if !app
+                .state
+                .contexts
+                .iter()
+                .any(|e| e.name == current_ctx_name)
+            {
+                app.state
+                    .contexts
+                    .push(ContextEntry::new(current_ctx_name.clone()));
+            }
+
             if !app.context_dir(&app.state.current_context).exists() {
                 let new_context = Context::new(app.state.current_context.clone());
                 app.save_current_context(&new_context)?;
@@ -318,6 +334,20 @@ async fn execute_from_input(
             let actual_name = resolve_context_name(app, name)?;
             let prev_context = app.state.current_context.clone();
             app.state.switch_context(actual_name)?;
+
+            // Ensure ContextEntry exists in state.contexts before proceeding
+            let current_ctx_name = app.state.current_context.clone();
+            if !app
+                .state
+                .contexts
+                .iter()
+                .any(|e| e.name == current_ctx_name)
+            {
+                app.state
+                    .contexts
+                    .push(ContextEntry::new(current_ctx_name.clone()));
+            }
+
             if !app.context_dir(&app.state.current_context).exists() {
                 let new_context = Context::new(app.state.current_context.clone());
                 app.save_current_context(&new_context)?;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -2830,6 +2830,40 @@ not valid json at all
         assert!(!result);
     }
 
+    #[test]
+    fn test_touch_context_with_destroy_settings_on_new_context() {
+        let (mut app, _temp) = create_test_app();
+
+        // Simulate what happens when switching to a new context with debug settings:
+        // 1. Context entry is added to state.contexts (our fix)
+        app.state
+            .contexts
+            .push(ContextEntry::new("new-test-context"));
+
+        // 2. Debug settings are applied via touch_context_with_destroy_settings
+        let result = app
+            .touch_context_with_destroy_settings("new-test-context", None, Some(60))
+            .unwrap();
+        assert!(
+            result,
+            "Should successfully apply debug settings to new context"
+        );
+
+        // 3. Verify the destroy settings were actually saved
+        let entry = app
+            .state
+            .contexts
+            .iter()
+            .find(|e| e.name == "new-test-context")
+            .unwrap();
+        assert_eq!(entry.destroy_after_seconds_inactive, 60);
+        assert_eq!(entry.destroy_at, 0);
+        assert!(
+            entry.last_activity_at > 0,
+            "last_activity_at should be updated by touch"
+        );
+    }
+
     // === Auto-destroy tests ===
 
     #[test]


### PR DESCRIPTION
the (debug) destroy settings were never saved because touch_context_with_destroy_settings() was trying to apply the settings to contexts in state.json that didn't exist yet.