### PR TITLE
implement pre_tool_output and post_tool_output hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,12 +85,13 @@ Defined in `tools/file_tools.rs`:
 
 ### Hooks
 
-21 hook points in `tools/hooks.rs`. Plugins register via `"hooks": [...]` in schema.
+23 hook points in `tools/hooks.rs`. Plugins register via `"hooks": [...]` in schema.
 
 ```
 on_start, on_end
 pre_message, post_message
 pre_tool, post_tool
+pre_tool_output, post_tool_output
 pre_system_prompt, post_system_prompt
 pre_send_message, post_send_message
 on_context_switch

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -31,6 +31,8 @@ Chibi supports a hooks system that allows plugins to register for lifecycle even
 |------|------|------------|
 | `pre_tool` | Before executing a tool | Yes (arguments, can block) |
 | `post_tool` | After executing a tool | No |
+| `pre_tool_output` | After tool execution, before caching | Yes (output, can block/replace) |
+| `post_tool_output` | After tool output is processed | No |
 
 ### API Request Lifecycle
 
@@ -249,6 +251,47 @@ Or to block execution:
 ```
 
 Note: `cached` is `true` if the output was cached due to size.
+
+### pre_tool_output
+
+Called immediately after a tool returns its output, before any caching decisions. Can modify or replace the output entirely.
+
+```json
+{
+  "tool_name": "read_file",
+  "arguments": {"path": "Cargo.toml"},
+  "output": "raw tool output..."
+}
+```
+
+**Can return (to modify output):**
+```json
+{
+  "output": "modified output..."
+}
+```
+
+Or to block/replace entirely:
+```json
+{
+  "block": true,
+  "message": "Replacement message shown to LLM"
+}
+```
+
+### post_tool_output
+
+Called after tool output processing (including any pre_tool_output modifications and caching decisions). Observe only.
+
+```json
+{
+  "tool_name": "read_file",
+  "arguments": {"path": "Cargo.toml"},
+  "output": "original output (after pre_tool_output modifications)",
+  "final_output": "what the LLM will see (may be truncated if cached)",
+  "cached": false
+}
+```
 
 ### pre_cache_output
 

--- a/src/tools/hooks.rs
+++ b/src/tools/hooks.rs
@@ -16,6 +16,8 @@ pub enum HookPoint {
     PostMessage,
     PreTool,
     PostTool,
+    PreToolOutput,  // Before tool output is processed (can modify/block output)
+    PostToolOutput, // After tool output is processed (observe only)
     OnContextSwitch,
     PreClear,
     PostClear,
@@ -103,12 +105,14 @@ pub fn execute_hook(
 mod tests {
     use super::*;
 
-    // All 21 hook points for testing
+    // All 23 hook points for testing
     const ALL_HOOKS: &[(&str, HookPoint)] = &[
         ("pre_message", HookPoint::PreMessage),
         ("post_message", HookPoint::PostMessage),
         ("pre_tool", HookPoint::PreTool),
         ("post_tool", HookPoint::PostTool),
+        ("pre_tool_output", HookPoint::PreToolOutput),
+        ("post_tool_output", HookPoint::PostToolOutput),
         ("on_context_switch", HookPoint::OnContextSwitch),
         ("pre_clear", HookPoint::PreClear),
         ("post_clear", HookPoint::PostClear),


### PR DESCRIPTION
the pre_tool_hook can be used to filter or modify the output from a tool, or to block the output entirely.

pre_tool_output fires after tool execution, before caching post_tool_output fires after output processing (observe-only)

this resolves #36