### PR TITLE
make -p and -P take exactly two args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "shlex",
  "streamdown-parser",
  "streamdown-render",
  "tempfile",

--- a/crates/chibi-cli/Cargo.toml
+++ b/crates/chibi-cli/Cargo.toml
@@ -20,6 +20,7 @@ imgcatr = "0.1.4"
 futures-util = { version = "0.3.31", features = ["std"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+shlex = "1.3"
 toml = "0.8"
 tokio = { version = "1.49.0", features = ["full"] }
 base64.workspace = true

--- a/crates/chibi-cli/src/cli.rs
+++ b/crates/chibi-cli/src/cli.rs
@@ -233,13 +233,16 @@ pub struct Cli {
     pub ephemeral_username: Option<String>,
 
     // === Plugin/tool options ===
-    // Note: These are handled specially because they consume all remaining args
-    /// Run a plugin directly (-p NAME [ARGS...])
-    #[arg(short = 'p', long = "plugin", value_name = "NAME", num_args = 1.., allow_hyphen_values = true)]
+    /// Run a plugin directly (-p NAME "ARGS")
+    /// For args with spaces or special chars: -p myplugin "arg1 'quoted arg' arg2"
+    /// For no args: -p myplugin ""
+    #[arg(short = 'p', long = "plugin", value_names = ["NAME", "ARGS"], num_args = 2, allow_hyphen_values = true)]
     pub plugin: Option<Vec<String>>,
 
-    /// Call a tool directly (-P TOOL [ARGS...])
-    #[arg(short = 'P', long = "call-tool", value_name = "TOOL", num_args = 1.., allow_hyphen_values = true)]
+    /// Call a tool directly (-P TOOL JSON_ARGS)
+    /// Example: -P send_message '{"to":"foo","content":"hi"}'
+    /// For no args: -P mytool '{}'
+    #[arg(short = 'P', long = "call-tool", value_names = ["TOOL", "JSON"], num_args = 2, allow_hyphen_values = true)]
     pub call_tool: Option<Vec<String>>,
 
     // === Control flags ===
@@ -308,6 +311,9 @@ const CLI_AFTER_HELP: &str = r#"EXAMPLES:
   chibi -a hello                  Archive history, then send prompt
   chibi -b                        Check all inboxes, process any messages
   chibi -B work                   Check inbox for 'work' context only
+  chibi -p myplugin "arg1 arg2"   Run plugin with args (shell-style split)
+  chibi -P mytool '{}'            Call tool with empty JSON args
+  chibi -P send '{"to":"x"}'      Call tool with JSON args
   chibi --json-schema             Print JSON schema for --json-config
 
 FLAG BEHAVIOR:
@@ -422,16 +428,32 @@ impl Cli {
             }
         });
 
-        // Parse plugin invocation
-        let plugin = self.plugin.as_ref().map(|v| PluginInvocation {
-            name: v.first().cloned().unwrap_or_default(),
-            args: v.get(1..).unwrap_or(&[]).to_vec(),
-        });
+        // Parse plugin invocation with shell-style arg splitting
+        let plugin = if let Some(v) = &self.plugin {
+            let name = v.first().cloned().unwrap_or_default();
+            let args = if let Some(args_str) = v.get(1) {
+                if args_str.is_empty() {
+                    vec![]
+                } else {
+                    shlex::split(args_str).ok_or_else(|| {
+                        io::Error::new(
+                            ErrorKind::InvalidInput,
+                            format!("Invalid shell syntax in plugin args: {}", args_str),
+                        )
+                    })?
+                }
+            } else {
+                vec![]
+            };
+            Some(PluginInvocation { name, args })
+        } else {
+            None
+        };
 
-        // Parse call_tool invocation
+        // Parse call_tool invocation (takes JSON directly)
         let call_tool = self.call_tool.as_ref().map(|v| PluginInvocation {
             name: v.first().cloned().unwrap_or_default(),
-            args: v.get(1..).unwrap_or(&[]).to_vec(),
+            args: v.get(1).cloned().into_iter().collect(),
         });
 
         // Parse debug keys (comma-separated) to check for md=<file>
@@ -749,10 +771,10 @@ pub fn parse() -> io::Result<ChibiInput> {
 mod tests {
     use super::*;
 
-    /// Helper to create args from a command string
+    /// Helper to create args from a command string (shell-style parsing)
     fn args(s: &str) -> Vec<String> {
         std::iter::once("chibi".to_string())
-            .chain(s.split_whitespace().map(|s| s.to_string()))
+            .chain(shlex::split(s).unwrap_or_default())
             .collect()
     }
 
@@ -1126,7 +1148,8 @@ mod tests {
 
     #[test]
     fn test_plugin_short() {
-        let input = parse_input("-p myplugin").unwrap();
+        // -p now requires exactly 2 args: NAME and ARGS (use empty string for no args)
+        let input = parse_input("-p myplugin \"\"").unwrap();
         assert!(
             matches!(input.command, Command::RunPlugin { ref name, ref args }
             if name == "myplugin" && args.is_empty())
@@ -1136,7 +1159,8 @@ mod tests {
 
     #[test]
     fn test_plugin_with_args() {
-        let input = parse_input("-p myplugin list --all").unwrap();
+        // Args are now passed as a single quoted string, split using shell rules
+        let input = parse_input("-p myplugin \"list --all\"").unwrap();
         assert!(
             matches!(input.command, Command::RunPlugin { ref name, ref args }
             if name == "myplugin" && args == &["list", "--all"])
@@ -1145,10 +1169,11 @@ mod tests {
 
     #[test]
     fn test_call_tool_short() {
-        let input = parse_input("-P update_todos").unwrap();
+        // -P now requires exactly 2 args: TOOL and JSON (use {} for no args)
+        let input = parse_input("-P update_todos \"{}\"").unwrap();
         assert!(
             matches!(input.command, Command::CallTool { ref name, ref args }
-            if name == "update_todos" && args.is_empty())
+            if name == "update_todos" && args == &["{}"])
         );
         assert!(input.flags.no_chibi);
     }
@@ -1276,8 +1301,10 @@ mod tests {
     // === Plugin captures everything after ===
 
     #[test]
-    fn test_plugin_captures_trailing_flags() {
-        let input = parse_input("-p myplugin -l --verbose").unwrap();
+    fn test_plugin_no_longer_captures_trailing_flags() {
+        // With the new 2-arg format, flags after -p are parsed normally
+        let input = parse_input("-p myplugin '-l --verbose' -v").unwrap();
+        assert!(input.flags.verbose); // -v is now parsed as verbose flag
         assert!(
             matches!(input.command, Command::RunPlugin { ref name, ref args }
             if name == "myplugin" && args == &["-l", "--verbose"])
@@ -1286,11 +1313,55 @@ mod tests {
 
     #[test]
     fn test_plugin_verbose_before() {
-        let input = parse_input("-v -p myplugin arg1").unwrap();
+        let input = parse_input("-v -p myplugin \"arg1\"").unwrap();
         assert!(input.flags.verbose);
         assert!(
             matches!(input.command, Command::RunPlugin { ref name, ref args }
             if name == "myplugin" && args == &["arg1"])
+        );
+    }
+
+    #[test]
+    fn test_plugin_with_quoted_args() {
+        // Shell-style quoting within the args string
+        let input = parse_input("-p myplugin \"arg1 'with spaces' arg2\"").unwrap();
+        assert!(
+            matches!(input.command, Command::RunPlugin { ref name, ref args }
+            if name == "myplugin" && args == &["arg1", "with spaces", "arg2"])
+        );
+    }
+
+    #[test]
+    fn test_plugin_verbose_after() {
+        // Flags can now come after -p since it only takes 2 args
+        let input = parse_input("-p myplugin \"arg1\" -v").unwrap();
+        assert!(input.flags.verbose);
+        assert!(
+            matches!(input.command, Command::RunPlugin { ref name, ref args }
+            if name == "myplugin" && args == &["arg1"])
+        );
+    }
+
+    #[test]
+    fn test_call_tool_with_json() {
+        let input = parse_input("-P send_message '{\"to\":\"foo\",\"content\":\"hi\"}'").unwrap();
+        assert!(
+            matches!(input.command, Command::CallTool { ref name, ref args }
+            if name == "send_message" && args == &["{\"to\":\"foo\",\"content\":\"hi\"}"])
+        );
+    }
+
+    #[test]
+    fn test_call_tool_with_flags_after() {
+        // Flags can now come after -P since it only takes 2 args
+        let input = parse_input("-P mytool '{}' -v -C ephemeral").unwrap();
+        assert!(input.flags.verbose);
+        assert!(
+            matches!(input.context, ContextSelection::Ephemeral { ref name } if name == "ephemeral")
+        );
+        assert!(
+            matches!(input.command, Command::CallTool { ref name, ref args }
+            if name == "mytool" && args == &["{}"])
         );
     }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -74,8 +74,8 @@ chibi -c -            # current='work', previous='personal'
 
 | Flag | Description |
 |------|-------------|
-| `-p, --plugin <NAME> [ARGS...]` | Run a plugin directly (bypasses LLM) |
-| `-P, --call-tool <TOOL> [ARGS...]` | Call a tool directly (plugin or built-in) |
+| `-p, --plugin <NAME> "ARGS"` | Run a plugin directly with shell-style args |
+| `-P, --call-tool <TOOL> JSON` | Call a tool directly with JSON arguments |
 
 ## Cache Management
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -154,8 +154,21 @@ print("This plugin only handles hooks")
 Users can run plugins directly without the LLM using `-p` (plugin) or `-P` (call-tool):
 
 ```bash
-chibi -p myplugin arg1 arg2    # Run a plugin directly
-chibi -P update_todos '{"content": "..."}'  # Call any tool (plugin or built-in)
+chibi -p myplugin "arg1 arg2"        # Run a plugin with args (shell-style split)
+chibi -p myplugin "'with spaces'"    # Args with spaces need inner quotes
+chibi -p myplugin ""                 # No args (empty string required)
+chibi -P update_todos '{}'           # Call tool with empty JSON
+chibi -P send '{"to":"x"}'           # Call tool with JSON args
+```
+
+Both flags take exactly 2 arguments. For `-p`, the second argument is a shell-style
+args string that gets split into an array. For `-P`, it's a JSON object passed directly.
+
+This allows mixing with other flags in any order:
+
+```bash
+chibi -p myplugin "list --all" -v    # -v works as verbose flag
+chibi -P send '{}' -C ephemeral      # -C works for context
 ```
 
 The args are passed as `{"args": ["arg1", "arg2"]}` in `CHIBI_TOOL_ARGS`. Design your plugin to handle both LLM calls (structured parameters) and direct calls (args array) if needed:
@@ -164,8 +177,8 @@ The args are passed as `{"args": ["arg1", "arg2"]}` in `CHIBI_TOOL_ARGS`. Design
 params = json.loads(os.environ["CHIBI_TOOL_ARGS"])
 
 if "args" in params:
-    # Direct invocation: chibi -P myplugin list --all
-    args = params["args"]
+    # Direct invocation: chibi -p myplugin "list --all"
+    args = params["args"]  # ["list", "--all"]
     # Parse args as needed
 else:
     # LLM invocation: structured parameters


### PR DESCRIPTION
crates/chibi-cli/Cargo.toml
- added shlex = "1.3" dependency for shell-style arg parsing

crates/chibi-cli/src/cli.rs
- -P/--call-tool: changed from num_args = 1.. to num_args = 2 (TOOL + JSON required)
- -p/--plugin: changed from num_args = 1.. to num_args = 2 (NAME + ARGS required)
- kept allow_hyphen_values = true on both (needed for args that start with -)
- plugin args now use shlex::split() for shell-style parsing
- updated CLI_AFTER_HELP with examples for the new syntax
- updated test helper args() to use shlex for proper quote handling
- updated and added tests for the new 2-arg format

docs updates:
- docs/cli-reference.md: updated flag descriptions
- docs/plugins.md: updated direct invocation section with new syntax and examples

new usage:

```
\# before (greedy, captured all trailing args)
chibi -p myplugin list --all -v   # -v got captured as plugin arg!

\# after (exactly 2 args, quotes for args string)
chibi -p myplugin "list --all" -v  # -v works as verbose flag

\# call_tool now requires JSON explicitly
chibi -P send_message '{}'         # empty JSON for no args
chibi -P send_message '{"to":"x"}' # JSON args
```

this fixes #91 and #92