### PR TITLE
feat: add spawn_agent and retrieve_content built-in tools (#112)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,9 @@ print("result")
 
 ## Hooks
 
-25 hook points in `tools/hooks.rs`. Plugins register via `"hooks": [...]` in schema.
+27 hook points in `tools/hooks.rs`. Plugins register via `"hooks": [...]` in schema.
 
-`on_start`, `on_end`, `pre_message`, `post_message`, `pre_tool`, `post_tool`, `pre_tool_output`, `post_tool_output`, `pre_system_prompt`, `post_system_prompt`, `pre_send_message`, `post_send_message`, `pre_clear`, `post_clear`, `pre_compact`, `post_compact`, `pre_rolling_compact`, `post_rolling_compact`, `pre_cache_output`, `post_cache_output`, `pre_api_tools`, `pre_api_request`, `pre_agentic_loop`, `post_tool_batch`, `pre_file_write`
+`on_start`, `on_end`, `pre_message`, `post_message`, `pre_tool`, `post_tool`, `pre_tool_output`, `post_tool_output`, `pre_system_prompt`, `post_system_prompt`, `pre_send_message`, `post_send_message`, `pre_clear`, `post_clear`, `pre_compact`, `post_compact`, `pre_rolling_compact`, `post_rolling_compact`, `pre_cache_output`, `post_cache_output`, `pre_api_tools`, `pre_api_request`, `pre_agentic_loop`, `post_tool_batch`, `pre_file_write`, `pre_spawn_agent`, `post_spawn_agent`
 
 Hook data: `CHIBI_HOOK` env var + stdin (JSON).
 

--- a/crates/chibi-core/src/lib.rs
+++ b/crates/chibi-core/src/lib.rs
@@ -57,7 +57,7 @@ pub use context::{Context, ContextEntry, Message, TranscriptEntry};
 pub use input::{Command, Flags, Inspectable};
 pub use partition::StorageConfig;
 pub use state::{AppState, StatePaths};
-pub use tools::{HookPoint, Tool};
+pub use tools::{HookPoint, SpawnOptions, Tool, spawn_agent};
 
 /// Returns ratatoskr's package version.
 pub fn ratatoskr_version() -> &'static str {

--- a/crates/chibi-core/src/tools/agent_tools.rs
+++ b/crates/chibi-core/src/tools/agent_tools.rs
@@ -1,0 +1,560 @@
+//! Agent tools for spawning sub-agents and retrieving content.
+//!
+//! Provides two LLM-facing tools:
+//! - `spawn_agent` — general-purpose sub-agent spawning (also usable as internal Rust API)
+//! - `retrieve_content` — reads files/URLs and processes content through a sub-agent
+//!
+//! Sub-agent calls are non-streaming (results are tool outputs, not user-facing).
+//! Hooks (`pre_spawn_agent` / `post_spawn_agent`) allow plugins to intercept or observe.
+
+use super::builtin::{BuiltinToolDef, ToolPropertyDef};
+use super::{HookPoint, Tool, execute_hook};
+use crate::config::ResolvedConfig;
+use crate::gateway;
+use crate::json_ext::JsonExt;
+use serde_json::json;
+use std::io::{self, ErrorKind};
+
+// === Tool Name Constants ===
+
+pub const SPAWN_AGENT_TOOL_NAME: &str = "spawn_agent";
+pub const RETRIEVE_CONTENT_TOOL_NAME: &str = "retrieve_content";
+
+// === Tool Definition Registry ===
+
+/// All agent tool definitions
+pub static AGENT_TOOL_DEFS: &[BuiltinToolDef] = &[
+    BuiltinToolDef {
+        name: SPAWN_AGENT_TOOL_NAME,
+        description: "Spawn a sub-agent with a custom system prompt to process input. Returns the sub-agent's response. Use for analysis, summarization, translation, or any task benefiting from a focused system prompt.",
+        properties: &[
+            ToolPropertyDef {
+                name: "system_prompt",
+                prop_type: "string",
+                description: "System prompt for the sub-agent",
+                default: None,
+            },
+            ToolPropertyDef {
+                name: "input",
+                prop_type: "string",
+                description: "Content for the sub-agent to process",
+                default: None,
+            },
+            ToolPropertyDef {
+                name: "model",
+                prop_type: "string",
+                description: "Model override (defaults to parent's model)",
+                default: None,
+            },
+            ToolPropertyDef {
+                name: "temperature",
+                prop_type: "number",
+                description: "Temperature override for the sub-agent",
+                default: None,
+            },
+            ToolPropertyDef {
+                name: "max_tokens",
+                prop_type: "integer",
+                description: "Max tokens override for the sub-agent",
+                default: None,
+            },
+        ],
+        required: &["system_prompt", "input"],
+    },
+    BuiltinToolDef {
+        name: RETRIEVE_CONTENT_TOOL_NAME,
+        description: "Read a file or fetch a URL, then process the content through a sub-agent with your instructions. Use for summarizing documents, extracting information, or analyzing content.",
+        properties: &[
+            ToolPropertyDef {
+                name: "source",
+                prop_type: "string",
+                description: "File path or URL to read",
+                default: None,
+            },
+            ToolPropertyDef {
+                name: "instructions",
+                prop_type: "string",
+                description: "How to process/summarize the content",
+                default: None,
+            },
+            ToolPropertyDef {
+                name: "model",
+                prop_type: "string",
+                description: "Model override (defaults to parent's model)",
+                default: None,
+            },
+            ToolPropertyDef {
+                name: "temperature",
+                prop_type: "number",
+                description: "Temperature override for the sub-agent",
+                default: None,
+            },
+            ToolPropertyDef {
+                name: "max_tokens",
+                prop_type: "integer",
+                description: "Max tokens override for the sub-agent",
+                default: None,
+            },
+        ],
+        required: &["source", "instructions"],
+    },
+];
+
+// === Types ===
+
+/// Options for sub-agent spawning.
+/// Designed to grow as ratatoskr gains model metadata and presets.
+#[derive(Debug, Clone, Default)]
+pub struct SpawnOptions {
+    /// Model override (uses parent's model if None)
+    pub model: Option<String>,
+    /// Temperature override
+    pub temperature: Option<f32>,
+    /// Max tokens override
+    pub max_tokens: Option<usize>,
+}
+
+impl SpawnOptions {
+    /// Parse spawn options from tool arguments.
+    pub fn from_args(args: &serde_json::Value) -> Self {
+        Self {
+            model: args.get_str("model").map(String::from),
+            temperature: args
+                .get("temperature")
+                .and_then(|v| v.as_f64())
+                .map(|f| f as f32),
+            max_tokens: args
+                .get("max_tokens")
+                .and_then(|v| v.as_u64())
+                .map(|n| n as usize),
+        }
+    }
+}
+
+/// Apply spawn options to a cloned config, returning the effective config.
+fn apply_spawn_options(config: &ResolvedConfig, opts: &SpawnOptions) -> ResolvedConfig {
+    let mut c = config.clone();
+    if let Some(ref model) = opts.model {
+        c.model = model.clone();
+    }
+    if let Some(temp) = opts.temperature {
+        c.api.temperature = Some(temp);
+    }
+    if let Some(max) = opts.max_tokens {
+        c.api.max_tokens = Some(max);
+    }
+    c
+}
+
+// === Content Reading ===
+
+/// Read a file, with tilde expansion.
+fn read_file(path: &str) -> io::Result<String> {
+    let resolved = if let Some(rest) = path.strip_prefix("~/") {
+        let home = dirs_next::home_dir().ok_or_else(|| {
+            io::Error::new(ErrorKind::NotFound, "Could not determine home directory")
+        })?;
+        home.join(rest)
+    } else if path == "~" {
+        dirs_next::home_dir().ok_or_else(|| {
+            io::Error::new(ErrorKind::NotFound, "Could not determine home directory")
+        })?
+    } else {
+        std::path::PathBuf::from(path)
+    };
+    std::fs::read_to_string(&resolved)
+        .map_err(|e| io::Error::new(e.kind(), format!("Failed to read '{}': {}", path, e)))
+}
+
+/// Fetch content from a URL with a 30-second timeout.
+async fn fetch_url(url: &str) -> io::Result<String> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| io::Error::other(format!("Failed to build HTTP client: {}", e)))?;
+
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| io::Error::other(format!("Failed to fetch '{}': {}", url, e)))?;
+
+    if !response.status().is_success() {
+        return Err(io::Error::other(format!(
+            "HTTP {} fetching '{}'",
+            response.status(),
+            url
+        )));
+    }
+
+    response
+        .text()
+        .await
+        .map_err(|e| io::Error::other(format!("Failed to read response from '{}': {}", url, e)))
+}
+
+/// Check if a source string is a URL (http:// or https://).
+fn is_url(source: &str) -> bool {
+    source.starts_with("http://") || source.starts_with("https://")
+}
+
+// === Core Functions ===
+
+/// Reusable async primitive — both tool-facing and internal.
+/// Fires pre/post_spawn_agent hooks.
+pub async fn spawn_agent(
+    config: &ResolvedConfig,
+    system_prompt: &str,
+    input: &str,
+    options: &SpawnOptions,
+    tools: &[Tool],
+) -> io::Result<String> {
+    let effective_config = apply_spawn_options(config, options);
+
+    // Fire pre_spawn_agent hook
+    let hook_data = json!({
+        "system_prompt": system_prompt,
+        "input": input,
+        "model": effective_config.model,
+        "temperature": effective_config.api.temperature,
+        "max_tokens": effective_config.api.max_tokens,
+    });
+    let hook_results = execute_hook(tools, HookPoint::PreSpawnAgent, &hook_data)?;
+
+    for (_hook_name, result) in &hook_results {
+        // Hook can provide a replacement response (skip LLM call)
+        if let Some(response) = result.get_str("response") {
+            return Ok(response.to_string());
+        }
+        // Hook can block the call entirely
+        if result.get_bool_or("block", false) {
+            let message = result
+                .get_str_or("message", "Sub-agent call blocked by hook")
+                .to_string();
+            return Ok(message);
+        }
+    }
+
+    // Build messages for the sub-agent call
+    let messages = vec![
+        json!({ "role": "system", "content": system_prompt }),
+        json!({ "role": "user", "content": input }),
+    ];
+
+    let response = gateway::chat(&effective_config, &messages).await?;
+
+    // Fire post_spawn_agent hook
+    let post_hook_data = json!({
+        "system_prompt": system_prompt,
+        "input": input,
+        "model": effective_config.model,
+        "response": response,
+    });
+    let _ = execute_hook(tools, HookPoint::PostSpawnAgent, &post_hook_data);
+
+    Ok(response)
+}
+
+/// Reads file or fetches URL, then delegates to spawn_agent.
+pub async fn retrieve_content(
+    config: &ResolvedConfig,
+    source: &str,
+    instructions: &str,
+    options: &SpawnOptions,
+    tools: &[Tool],
+) -> io::Result<String> {
+    // Fetch content
+    let content = if is_url(source) {
+        fetch_url(source).await?
+    } else {
+        read_file(source)?
+    };
+
+    if content.is_empty() {
+        return Ok(format!("Source '{}' is empty.", source));
+    }
+
+    // Build system prompt and input for the sub-agent
+    let system_prompt = "You are a content processing assistant. Follow the user's instructions to process the provided content. Be concise and focused.";
+    let input = format!(
+        "## Instructions\n{}\n\n## Content from: {}\n{}",
+        instructions, source, content
+    );
+
+    spawn_agent(config, system_prompt, &input, options, tools).await
+}
+
+// === Dispatcher & Utilities ===
+
+/// Check if a tool name is an agent tool.
+pub fn is_agent_tool(name: &str) -> bool {
+    matches!(name, SPAWN_AGENT_TOOL_NAME | RETRIEVE_CONTENT_TOOL_NAME)
+}
+
+/// Execute an agent tool by name.
+pub async fn execute_agent_tool(
+    config: &ResolvedConfig,
+    tool_name: &str,
+    args: &serde_json::Value,
+    tools: &[Tool],
+) -> io::Result<String> {
+    let options = SpawnOptions::from_args(args);
+
+    match tool_name {
+        SPAWN_AGENT_TOOL_NAME => {
+            let system_prompt = args.get_str("system_prompt").ok_or_else(|| {
+                io::Error::new(ErrorKind::InvalidInput, "Missing 'system_prompt' parameter")
+            })?;
+            let input = args.get_str("input").ok_or_else(|| {
+                io::Error::new(ErrorKind::InvalidInput, "Missing 'input' parameter")
+            })?;
+            spawn_agent(config, system_prompt, input, &options, tools).await
+        }
+        RETRIEVE_CONTENT_TOOL_NAME => {
+            let source = args.get_str("source").ok_or_else(|| {
+                io::Error::new(ErrorKind::InvalidInput, "Missing 'source' parameter")
+            })?;
+            let instructions = args.get_str("instructions").ok_or_else(|| {
+                io::Error::new(ErrorKind::InvalidInput, "Missing 'instructions' parameter")
+            })?;
+            retrieve_content(config, source, instructions, &options, tools).await
+        }
+        _ => Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("Unknown agent tool: {}", tool_name),
+        )),
+    }
+}
+
+/// Convert all agent tools to API format.
+pub fn all_agent_tools_to_api_format() -> Vec<serde_json::Value> {
+    AGENT_TOOL_DEFS
+        .iter()
+        .map(|def| def.to_api_format())
+        .collect()
+}
+
+/// Look up a specific agent tool definition by name.
+pub fn get_agent_tool_def(name: &str) -> Option<&'static BuiltinToolDef> {
+    AGENT_TOOL_DEFS.iter().find(|d| d.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // === Helper ===
+    fn get_tool_api(name: &str) -> serde_json::Value {
+        get_agent_tool_def(name)
+            .expect("tool should exist in registry")
+            .to_api_format()
+    }
+
+    // === Registry Tests ===
+
+    #[test]
+    fn test_agent_tool_registry_contains_all_tools() {
+        assert_eq!(AGENT_TOOL_DEFS.len(), 2);
+        let names: Vec<_> = AGENT_TOOL_DEFS.iter().map(|d| d.name).collect();
+        assert!(names.contains(&SPAWN_AGENT_TOOL_NAME));
+        assert!(names.contains(&RETRIEVE_CONTENT_TOOL_NAME));
+    }
+
+    #[test]
+    fn test_tool_constants() {
+        assert_eq!(SPAWN_AGENT_TOOL_NAME, "spawn_agent");
+        assert_eq!(RETRIEVE_CONTENT_TOOL_NAME, "retrieve_content");
+    }
+
+    #[test]
+    fn test_is_agent_tool() {
+        assert!(is_agent_tool(SPAWN_AGENT_TOOL_NAME));
+        assert!(is_agent_tool(RETRIEVE_CONTENT_TOOL_NAME));
+        assert!(!is_agent_tool("file_head"));
+        assert!(!is_agent_tool("other_tool"));
+    }
+
+    #[test]
+    fn test_get_agent_tool_def() {
+        assert!(get_agent_tool_def(SPAWN_AGENT_TOOL_NAME).is_some());
+        assert!(get_agent_tool_def(RETRIEVE_CONTENT_TOOL_NAME).is_some());
+        assert!(get_agent_tool_def("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_all_agent_tools_to_api_format() {
+        let tools = all_agent_tools_to_api_format();
+        assert_eq!(tools.len(), 2);
+        for tool in &tools {
+            assert_eq!(tool["type"], "function");
+            assert!(tool["function"]["name"].is_string());
+        }
+    }
+
+    // === spawn_agent Tool API ===
+
+    #[test]
+    fn test_spawn_agent_tool_api_format() {
+        let tool = get_tool_api(SPAWN_AGENT_TOOL_NAME);
+        assert_eq!(tool["type"], "function");
+        assert_eq!(tool["function"]["name"], SPAWN_AGENT_TOOL_NAME);
+        let required = tool["function"]["parameters"]["required"]
+            .as_array()
+            .unwrap();
+        assert!(required.contains(&json!("system_prompt")));
+        assert!(required.contains(&json!("input")));
+        assert_eq!(required.len(), 2);
+    }
+
+    // === retrieve_content Tool API ===
+
+    #[test]
+    fn test_retrieve_content_tool_api_format() {
+        let tool = get_tool_api(RETRIEVE_CONTENT_TOOL_NAME);
+        assert_eq!(tool["type"], "function");
+        assert_eq!(tool["function"]["name"], RETRIEVE_CONTENT_TOOL_NAME);
+        let required = tool["function"]["parameters"]["required"]
+            .as_array()
+            .unwrap();
+        assert!(required.contains(&json!("source")));
+        assert!(required.contains(&json!("instructions")));
+        assert_eq!(required.len(), 2);
+    }
+
+    // === SpawnOptions ===
+
+    #[test]
+    fn test_spawn_options_from_args_all_fields() {
+        let args = json!({
+            "model": "gpt-4",
+            "temperature": 0.7,
+            "max_tokens": 1000,
+        });
+        let opts = SpawnOptions::from_args(&args);
+        assert_eq!(opts.model.as_deref(), Some("gpt-4"));
+        assert_eq!(opts.temperature, Some(0.7));
+        assert_eq!(opts.max_tokens, Some(1000));
+    }
+
+    #[test]
+    fn test_spawn_options_from_args_partial() {
+        let args = json!({ "model": "claude-3" });
+        let opts = SpawnOptions::from_args(&args);
+        assert_eq!(opts.model.as_deref(), Some("claude-3"));
+        assert!(opts.temperature.is_none());
+        assert!(opts.max_tokens.is_none());
+    }
+
+    #[test]
+    fn test_spawn_options_from_args_empty() {
+        let args = json!({});
+        let opts = SpawnOptions::from_args(&args);
+        assert!(opts.model.is_none());
+        assert!(opts.temperature.is_none());
+        assert!(opts.max_tokens.is_none());
+    }
+
+    // === apply_spawn_options ===
+
+    #[test]
+    fn test_apply_spawn_options_model_override() {
+        let config = make_test_config();
+        let opts = SpawnOptions {
+            model: Some("new-model".to_string()),
+            ..Default::default()
+        };
+        let result = apply_spawn_options(&config, &opts);
+        assert_eq!(result.model, "new-model");
+        // Other fields unchanged
+        assert_eq!(result.api.temperature, config.api.temperature);
+    }
+
+    #[test]
+    fn test_apply_spawn_options_temperature_override() {
+        let config = make_test_config();
+        let opts = SpawnOptions {
+            temperature: Some(0.9),
+            ..Default::default()
+        };
+        let result = apply_spawn_options(&config, &opts);
+        assert_eq!(result.api.temperature, Some(0.9));
+        assert_eq!(result.model, config.model);
+    }
+
+    #[test]
+    fn test_apply_spawn_options_no_overrides() {
+        let config = make_test_config();
+        let opts = SpawnOptions::default();
+        let result = apply_spawn_options(&config, &opts);
+        assert_eq!(result.model, config.model);
+        assert_eq!(result.api.temperature, config.api.temperature);
+        assert_eq!(result.api.max_tokens, config.api.max_tokens);
+    }
+
+    // === read_file ===
+
+    #[test]
+    fn test_read_file_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.txt");
+        std::fs::write(&path, "hello world").unwrap();
+        let result = read_file(path.to_str().unwrap()).unwrap();
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn test_read_file_not_found() {
+        let result = read_file("/nonexistent/path/to/file.txt");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_file_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.txt");
+        std::fs::write(&path, "").unwrap();
+        let result = read_file(path.to_str().unwrap()).unwrap();
+        assert_eq!(result, "");
+    }
+
+    // === Source classification ===
+
+    #[test]
+    fn test_is_url() {
+        assert!(is_url("http://example.com"));
+        assert!(is_url("https://example.com/path"));
+        assert!(!is_url("/home/user/file.txt"));
+        assert!(!is_url("~/file.txt"));
+        assert!(!is_url("relative/path"));
+    }
+
+    // === Test helpers ===
+
+    fn make_test_config() -> ResolvedConfig {
+        use crate::config::{ApiParams, ToolsConfig};
+        ResolvedConfig {
+            api_key: "test-key".to_string(),
+            model: "test-model".to_string(),
+            context_window_limit: 128000,
+            warn_threshold_percent: 0.8,
+            auto_compact: false,
+            auto_compact_threshold: 0.9,
+            max_recursion_depth: 5,
+            max_empty_responses: 3,
+            username: "user".to_string(),
+            reflection_enabled: false,
+            tool_output_cache_threshold: 5000,
+            tool_cache_max_age_days: 7,
+            auto_cleanup_cache: false,
+            tool_cache_preview_chars: 500,
+            file_tools_allowed_paths: vec![],
+            api: ApiParams {
+                temperature: Some(0.5),
+                max_tokens: Some(4096),
+                ..Default::default()
+            },
+            tools: ToolsConfig::default(),
+            fallback_tool: "call_agent".to_string(),
+        }
+    }
+}

--- a/crates/chibi-core/src/tools/hooks.rs
+++ b/crates/chibi-core/src/tools/hooks.rs
@@ -37,6 +37,8 @@ pub enum HookPoint {
     PreAgenticLoop,   // Before entering the tool loop (can override fallback)
     PostToolBatch,    // After processing a batch of tool calls (can override fallback)
     PreFileWrite,     // Before file write/patch (can approve/deny/modify operation)
+    PreSpawnAgent, // Before sub-agent call (can intercept/replace with {"response": "..."} or block)
+    PostSpawnAgent, // After sub-agent call (observe only)
 }
 
 /// Execute a hook on all tools that registered for it
@@ -115,7 +117,7 @@ pub fn execute_hook(
 mod tests {
     use super::*;
 
-    // All 24 hook points for testing
+    // All 26 hook points for testing
     const ALL_HOOKS: &[(&str, HookPoint)] = &[
         ("pre_message", HookPoint::PreMessage),
         ("post_message", HookPoint::PostMessage),
@@ -142,6 +144,8 @@ mod tests {
         ("pre_agentic_loop", HookPoint::PreAgenticLoop),
         ("post_tool_batch", HookPoint::PostToolBatch),
         ("pre_file_write", HookPoint::PreFileWrite),
+        ("pre_spawn_agent", HookPoint::PreSpawnAgent),
+        ("post_spawn_agent", HookPoint::PostSpawnAgent),
     ];
 
     #[test]

--- a/crates/chibi-core/src/tools/mod.rs
+++ b/crates/chibi-core/src/tools/mod.rs
@@ -6,6 +6,7 @@
 //! - File tools for examining cached tool outputs
 //! - Hook system for plugin lifecycle events
 
+pub mod agent_tools;
 mod builtin;
 pub mod file_tools;
 mod hooks;
@@ -48,6 +49,15 @@ pub use file_tools::{execute_file_tool, is_file_tool};
 
 // Re-export file write tool names for permission gating
 pub use file_tools::{PATCH_FILE_TOOL_NAME, WRITE_FILE_TOOL_NAME};
+
+// Re-export agent tool registry functions
+pub use agent_tools::{all_agent_tools_to_api_format, get_agent_tool_def};
+
+// Re-export agent tool execution and utilities
+pub use agent_tools::{execute_agent_tool, is_agent_tool, spawn_agent};
+
+// Re-export agent tool types and constants
+pub use agent_tools::{RETRIEVE_CONTENT_TOOL_NAME, SPAWN_AGENT_TOOL_NAME, SpawnOptions};
 
 /// Metadata for tool behavior in the agentic loop
 #[derive(Debug, Clone, Default)]

--- a/docs/agentic.md
+++ b/docs/agentic.md
@@ -17,6 +17,8 @@ The LLM always has access to these tools (no setup required):
 | `file_lines` | Read a specific line range from a cached output or file |
 | `file_grep` | Search for a pattern in a cached output or file |
 | `cache_list` | List all cached tool outputs for the current context |
+| `spawn_agent` | Spawn a sub-agent with a custom system prompt to process input |
+| `retrieve_content` | Read a file/URL and process content through a sub-agent |
 
 ## External Plugins
 
@@ -181,6 +183,32 @@ The `pre_send_message` hook can intercept delivery for custom routing:
 See [hooks.md](hooks.md#pre_send_message) for details.
 
 ## Sub-Agents
+
+### Built-in Agent Tools
+
+Chibi provides two built-in tools for spawning sub-agents — separate LLM calls with their own system prompts that return results as tool output.
+
+**`spawn_agent`** — General-purpose sub-agent spawning:
+```json
+{
+  "system_prompt": "You are a code reviewer. Be concise.",
+  "input": "Review this function:\ndef add(a, b): return a + b",
+  "model": "anthropic/claude-haiku",
+  "temperature": 0.3
+}
+```
+
+**`retrieve_content`** — Read a file or fetch a URL, then process through a sub-agent:
+```json
+{
+  "source": "https://example.com/api-docs",
+  "instructions": "Summarize the authentication section"
+}
+```
+
+Both tools accept optional `model`, `temperature`, and `max_tokens` overrides. Without overrides, the parent's model and settings are used.
+
+Sub-agent calls are non-streaming (results returned as tool output). Plugins can intercept or replace sub-agent calls via `pre_spawn_agent` / `post_spawn_agent` hooks — see [hooks.md](hooks.md#pre_spawn_agent).
 
 ### Ephemeral Context Flag
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -48,6 +48,13 @@ Chibi supports a hooks system that allows plugins to register for lifecycle even
 | `pre_agentic_loop` | Before entering the tool loop | Yes (fallback target) |
 | `post_tool_batch` | After processing a batch of tool calls | Yes (fallback target) |
 
+### Sub-Agent Lifecycle
+
+| Hook | When | Can Modify |
+|------|------|------------|
+| `pre_spawn_agent` | Before a sub-agent LLM call | Yes (can provide response or block) |
+| `post_spawn_agent` | After sub-agent returns | No |
+
 ### Tool Output Caching
 
 | Hook | When | Can Modify |
@@ -170,6 +177,7 @@ Called before tools are sent to the API. Allows dynamic filtering of which tools
 Tool types are:
 - `builtin`: update_todos, update_goals, update_reflection, send_message
 - `file`: file_head, file_tail, file_lines, file_grep, cache_list
+- `agent`: spawn_agent, retrieve_content
 - `plugin`: Tools loaded from the plugins directory
 
 **Can return (to filter tools):**
@@ -408,6 +416,46 @@ Notification after output has been cached.
   "content": "message content",
   "context_name": "default",
   "delivery_result": "Message delivered to 'research' via local inbox"
+}
+```
+
+### pre_spawn_agent
+
+Called before a sub-agent LLM call (from `spawn_agent` or `retrieve_content` tools). Can intercept and replace the call entirely, or block it.
+
+```json
+{
+  "system_prompt": "You are a summarizer...",
+  "input": "Content to process...",
+  "model": "anthropic/claude-sonnet-4",
+  "temperature": 0.7,
+  "max_tokens": 4096
+}
+```
+
+**Can return (to replace the LLM call):**
+```json
+{
+  "response": "Pre-computed or cached response"
+}
+```
+
+Or to block:
+```json
+{
+  "block": true,
+  "message": "Sub-agent calls are not allowed in this context"
+}
+```
+
+### post_spawn_agent
+
+```json
+{
+  "system_prompt": "You are a summarizer...",
+  "input": "Content to process...",
+  "model": "anthropic/claude-sonnet-4",
+  "response": "The sub-agent's response..."
 }
 ```
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -113,6 +113,8 @@ Plugins can register for lifecycle hooks by including a `hooks` array in the sch
 | `post_system_prompt` | After system prompt built | `{context_name, summary, todos, goals}` |
 | `pre_send_message` | Before inter-context message | `{from, to, content, context_name}` |
 | `post_send_message` | After inter-context message | `{from, to, content, context_name, delivery_result}` |
+| `pre_spawn_agent` | Before sub-agent LLM call | `{system_prompt, input, model, temperature, max_tokens}` |
+| `post_spawn_agent` | After sub-agent LLM call | `{system_prompt, input, model, response}` |
 
 ### Hook Output
 
@@ -123,6 +125,7 @@ Hooks can return JSON to stdout. For most hooks, this is informational. Some hoo
 - `pre_tool`: Return `{"arguments": {...}}` to modify tool arguments before execution
 - `pre_system_prompt` / `post_system_prompt`: Return `{"inject": "text"}` to add content to the system prompt
 - `pre_send_message`: Return `{"delivered": true, "via": "..."}` to intercept message delivery
+- `pre_spawn_agent`: Return `{"response": "..."}` to replace the LLM call, or `{"block": true, "message": "..."}` to block it
 
 Return empty output or `{}` if you have nothing to contribute.
 
@@ -277,4 +280,8 @@ Chibi provides several built-in tools that don't require plugins:
 - `file_grep` - Search for patterns
 - `cache_list` - List cached outputs
 
-These are always available to the LLM. See [agentic.md](agentic.md) for details on tool output caching.
+**Agent tools** (for spawning sub-agents):
+- `spawn_agent` - Spawn a sub-agent with a custom system prompt
+- `retrieve_content` - Read a file/URL and process it through a sub-agent
+
+These are always available to the LLM. See [agentic.md](agentic.md) for details on sub-agents and tool output caching.


### PR DESCRIPTION
sub-agent spawning primitive with hooks, model/temperature/max_tokens
overrides, file reading, URL fetching, and full test coverage.

closes #112
