### PR TITLE
feat: parallel tool execution (#118)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,7 +1034,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2965,8 +2965,8 @@ dependencies = [
 
 [[package]]
 name = "ratatoskr"
-version = "0.1.1"
-source = "git+https://github.com/emesal/ratatoskr.git?branch=main#159a46f9fb062f59d25bce8a962aead6fdfb561b"
+version = "0.1.2"
+source = "git+https://github.com/emesal/ratatoskr.git?branch=dev#2fca148ab2fb36889b97770b2623da68d582b691"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4658,7 +4658,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ streamdown-render = { path = "crates/chibi-cli/vendor/streamdown-rs/crates/strea
 streamdown-plugin = { path = "crates/chibi-cli/vendor/streamdown-rs/crates/streamdown-plugin" }
 
 # Ratatoskr (LLM API client)
-ratatoskr = { git = "https://github.com/emesal/ratatoskr.git", branch = "main" }
+ratatoskr = { git = "https://github.com/emesal/ratatoskr.git", branch = "dev" }
 
 [workspace.lints.rust]
 dead_code = "deny"

--- a/crates/chibi-core/src/tools/mod.rs
+++ b/crates/chibi-core/src/tools/mod.rs
@@ -63,7 +63,8 @@ pub use agent_tools::{RETRIEVE_CONTENT_TOOL_NAME, SPAWN_AGENT_TOOL_NAME, SpawnOp
 #[derive(Debug, Clone, Default)]
 pub struct ToolMetadata {
     /// Can this tool run in parallel with others? (default: true)
-    /// NOTE: Parallel execution not yet implemented - see #101
+    /// Tools with parallel=true are executed concurrently via join_all.
+    /// Flow control tools are always sequential regardless of this flag.
     pub parallel: bool,
 
     /// Is this a flow control tool? (default: false)


### PR DESCRIPTION
tools marked parallel=true now run concurrently via join_all, while flow control and sequential tools execute after the parallel batch. results are emitted in original order regardless of completion order.

also passes parallel_tool_calls and tool_choice through the gateway to ratatoskr (switched to dev branch for new ChatOptions fields).

refactors execute_single_tool into a sink-free execute_tool_pure core that collects diagnostics into a vec, enabling safe concurrent execution without &mut sink access. join_all runs on the current task (no spawn), keeping compatibility with AppState's !Send RefCell.

this closes #118