### PR TITLE
add test coverage for chibi struct methods and chibi-json integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,6 +1051,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/crates/chibi-core/src/chibi.rs
+++ b/crates/chibi-core/src/chibi.rs
@@ -461,13 +461,59 @@ pub fn project_index_db_path(root: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::StatePaths;
+    use crate::config::{ApiParams, ToolsConfig};
+    use crate::partition::StorageConfig;
+    use tempfile::TempDir;
 
     // Note: Most tests require a real chibi directory structure.
     // These are basic sanity tests.
 
+    /// create a test chibi instance with a temporary directory.
+    /// returns both for lifetime management (tempdir must outlive chibi).
+    fn create_test_chibi() -> (Chibi, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let config = crate::config::Config {
+            api_key: Some("test-key".to_string()),
+            model: Some("test-model".to_string()),
+            context_window_limit: Some(8000),
+            warn_threshold_percent: 75.0,
+            verbose: false,
+            hide_tool_calls: false,
+            no_tool_calls: false,
+            auto_compact: false,
+            auto_compact_threshold: 80.0,
+            reflection_enabled: true,
+            reflection_character_limit: 10000,
+            fuel: 15,
+            fuel_empty_response_cost: 15,
+            username: "testuser".to_string(),
+            lock_heartbeat_seconds: 30,
+            rolling_compact_drop_percentage: 50.0,
+            tool_output_cache_threshold: 4000,
+            tool_cache_max_age_days: 7,
+            auto_cleanup_cache: true,
+            tool_cache_preview_chars: 500,
+            file_tools_allowed_paths: vec![],
+            api: ApiParams::default(),
+            storage: StorageConfig::default(),
+            fallback_tool: "call_user".to_string(),
+            tools: ToolsConfig::default(),
+            url_policy: None,
+        };
+        let app = AppState::from_dir(temp_dir.path().to_path_buf(), config).unwrap();
+        let chibi = Chibi {
+            project_root: temp_dir.path().to_path_buf(),
+            app,
+            tools: vec![],
+            permission_handler: None,
+        };
+        (chibi, temp_dir)
+    }
+
     #[test]
     fn test_chibi_facade_exists() {
-        // Basic compile test - if this compiles, the facade is properly defined
+        // basic compile test - if this compiles, the facade is properly defined
         fn _takes_chibi(_c: Chibi) {}
     }
 
@@ -564,5 +610,163 @@ mod tests {
             project_index_db_path(&root),
             PathBuf::from("/my/project/.chibi/codebase.db")
         );
+    }
+
+    // === Chibi struct method tests ===
+
+    #[test]
+    fn test_init_no_hooks() {
+        let (chibi, _tmp) = create_test_chibi();
+        let results = chibi.init().unwrap();
+        // no plugins loaded, so no hook results
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_shutdown_no_hooks() {
+        let (chibi, _tmp) = create_test_chibi();
+        let results = chibi.shutdown().unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_init_hook_data() {
+        // we can't easily test hook *execution* without a real hook plugin,
+        // but we verify init() succeeds and returns the right shape.
+        // the hook_data json built internally contains chibi_home, project_root,
+        // and tool_count — verified indirectly by init() not erroring.
+        let (chibi, _tmp) = create_test_chibi();
+        let results = chibi.init().unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_clear_context_nonexistent() {
+        // clear_context calls get_or_create_context first (creates if missing),
+        // then clears it — should succeed as a no-op on fresh context
+        let (chibi, _tmp) = create_test_chibi();
+        chibi.clear_context("nonexistent").unwrap();
+    }
+
+    #[test]
+    fn test_clear_context_with_messages() {
+        let (chibi, _tmp) = create_test_chibi();
+        let ctx_name = "test-ctx";
+
+        // add a message to the context
+        let mut context = chibi.app.get_or_create_context(ctx_name).unwrap();
+        chibi
+            .app
+            .add_message(&mut context, "user".to_string(), "hello".to_string());
+        assert_eq!(context.messages.len(), 1);
+        chibi.app.save_context(&context).unwrap();
+
+        // clear should succeed
+        chibi.clear_context(ctx_name).unwrap();
+
+        // verify the context is now empty
+        let cleared = chibi.app.get_or_create_context(ctx_name).unwrap();
+        assert!(cleared.messages.is_empty());
+    }
+
+    #[test]
+    fn test_list_contexts_empty() {
+        let (chibi, _tmp) = create_test_chibi();
+        assert!(chibi.list_contexts().is_empty());
+    }
+
+    #[test]
+    fn test_list_contexts_after_create() {
+        let (mut chibi, _tmp) = create_test_chibi();
+
+        // save contexts to disk then sync in-memory state
+        for name in &["alpha", "beta"] {
+            let ctx = chibi.app.get_or_create_context(name).unwrap();
+            chibi.app.save_context(&ctx).unwrap();
+        }
+        chibi.app.sync_state_with_filesystem().unwrap();
+
+        let names = chibi.list_contexts();
+        assert!(names.contains(&"alpha".to_string()));
+        assert!(names.contains(&"beta".to_string()));
+        assert_eq!(names.len(), 2);
+    }
+
+    #[test]
+    fn test_resolve_config_defaults() {
+        let (chibi, _tmp) = create_test_chibi();
+        let config = chibi.resolve_config("default", None).unwrap();
+        // should reflect the values from create_test_chibi's Config
+        assert_eq!(config.model, "test-model");
+        assert_eq!(config.username, "testuser");
+        assert_eq!(config.fuel, 15);
+        assert_eq!(config.context_window_limit, 8000);
+        assert!(!config.verbose);
+    }
+
+    #[test]
+    fn test_resolve_config_with_local_override() {
+        let (chibi, _tmp) = create_test_chibi();
+        let ctx_name = "override-ctx";
+
+        // ensure the context directory exists
+        let ctx = chibi.app.get_or_create_context(ctx_name).unwrap();
+        chibi.app.save_context(&ctx).unwrap();
+
+        // write a local.toml that overrides the model
+        let local_toml = chibi.app.context_dir(ctx_name).join("local.toml");
+        std::fs::write(&local_toml, "model = \"local-model\"\nfuel = 99\n").unwrap();
+
+        let config = chibi.resolve_config(ctx_name, None).unwrap();
+        assert_eq!(config.model, "local-model");
+        assert_eq!(config.fuel, 99);
+        // non-overridden values should still come from global config
+        assert_eq!(config.username, "testuser");
+    }
+
+    #[test]
+    fn test_save_persists_state() {
+        let (chibi, tmp) = create_test_chibi();
+        chibi.save().unwrap();
+        let state_path = tmp.path().join("state.json");
+        assert!(state_path.exists());
+    }
+
+    #[test]
+    fn test_home_dir() {
+        let (chibi, tmp) = create_test_chibi();
+        assert_eq!(chibi.home_dir(), tmp.path());
+    }
+
+    #[test]
+    fn test_tool_count_empty() {
+        let (chibi, _tmp) = create_test_chibi();
+        assert_eq!(chibi.tool_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_execute_tool_not_found() {
+        let (chibi, _tmp) = create_test_chibi();
+        let result = chibi
+            .execute_tool("default", "nonexistent_tool", serde_json::json!({}))
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert!(err.to_string().contains("nonexistent_tool"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_tool_builtin() {
+        let (chibi, _tmp) = create_test_chibi();
+        let result = chibi
+            .execute_tool(
+                "default",
+                "update_todos",
+                serde_json::json!({"content": "- [ ] write tests"}),
+            )
+            .await;
+        let output = result.unwrap();
+        assert!(output.contains("Todos updated"));
     }
 }

--- a/crates/chibi-json/Cargo.toml
+++ b/crates/chibi-json/Cargo.toml
@@ -15,5 +15,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.49.0", features = ["full"] }
 
+[dev-dependencies]
+tempfile = "3.19"
+
 [lints.rust]
 dead_code = "deny"

--- a/crates/chibi-json/tests/integration.rs
+++ b/crates/chibi-json/tests/integration.rs
@@ -1,6 +1,9 @@
+use std::path::Path;
 use std::process::Command;
 
-/// Helper: run chibi-json with JSON input on stdin
+// === helpers ===
+
+/// run chibi-json with JSON input on stdin
 fn run_chibi_json(input: &str) -> (String, String, bool) {
     let output = Command::new(env!("CARGO_BIN_EXE_chibi-json"))
         .stdin(std::process::Stdio::piped())
@@ -19,6 +22,52 @@ fn run_chibi_json(input: &str) -> (String, String, bool) {
         output.status.success(),
     )
 }
+
+/// run chibi-json with a serde_json::Value, injecting home and project_root
+fn run_chibi_json_with_home(
+    mut input_json: serde_json::Value,
+    home: &Path,
+) -> (String, String, bool) {
+    let obj = input_json
+        .as_object_mut()
+        .expect("input must be a JSON object");
+    obj.insert("home".into(), serde_json::json!(home));
+    obj.insert("project_root".into(), serde_json::json!(home));
+    run_chibi_json(&input_json.to_string())
+}
+
+/// create a minimal context directory with transcript entries
+fn setup_context(home: &Path, name: &str) {
+    let ctx_dir = home.join("contexts").join(name);
+    std::fs::create_dir_all(&ctx_dir).expect("failed to create context dir");
+    let entries = concat!(
+        r#"{"id":"1","timestamp":1234567890,"from":"user","to":"ctx","content":"hello","entry_type":"message"}"#,
+        "\n",
+        r#"{"id":"2","timestamp":1234567891,"from":"ctx","to":"user","content":"hi there","entry_type":"message"}"#,
+        "\n",
+    );
+    std::fs::write(ctx_dir.join("context.jsonl"), entries).expect("failed to write context.jsonl");
+}
+
+/// validate that every non-empty line of stdout parses as valid JSON with a "type"
+/// or "entry_type" field (the latter for raw TranscriptEntry lines from show_log)
+fn assert_valid_jsonl(stdout: &str) {
+    for (i, line) in stdout.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let parsed: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("line {} is not valid JSON: {}\nline: {}", i, e, line));
+        assert!(
+            parsed.get("type").is_some() || parsed.get("entry_type").is_some(),
+            "line {} missing 'type' or 'entry_type' field: {}",
+            i,
+            line
+        );
+    }
+}
+
+// === existing flag tests ===
 
 #[test]
 fn test_json_schema_flag() {
@@ -77,4 +126,355 @@ fn test_show_help_command() {
     let (stdout, _, success) = run_chibi_json(&input.to_string());
     assert!(success, "chibi-json failed");
     assert!(stdout.contains("json-schema"));
+}
+
+// === command coverage tests ===
+
+#[test]
+fn test_list_contexts_empty() {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    let (stdout, _, success) = run_chibi_json_with_home(
+        serde_json::json!({"command": "list_contexts", "context": "default"}),
+        tmp.path(),
+    );
+    assert!(success, "list_contexts on empty home should succeed");
+    assert_valid_jsonl(&stdout);
+}
+
+#[test]
+fn test_list_contexts_with_data() {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    setup_context(tmp.path(), "alpha");
+    setup_context(tmp.path(), "beta");
+    let (stdout, _, success) = run_chibi_json_with_home(
+        serde_json::json!({"command": "list_contexts", "context": "default"}),
+        tmp.path(),
+    );
+    assert!(success, "list_contexts should succeed");
+    assert!(stdout.contains("alpha"), "should list alpha context");
+    assert!(stdout.contains("beta"), "should list beta context");
+    assert_valid_jsonl(&stdout);
+}
+
+#[test]
+fn test_list_current_context() {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    setup_context(tmp.path(), "myctx");
+    let (stdout, _, success) = run_chibi_json_with_home(
+        serde_json::json!({"command": "list_current_context", "context": "myctx"}),
+        tmp.path(),
+    );
+    assert!(success, "list_current_context should succeed");
+    assert!(stdout.contains("myctx"), "should mention the context name");
+    assert_valid_jsonl(&stdout);
+}
+
+#[test]
+fn test_destroy_context() {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    setup_context(tmp.path(), "doomed");
+    let ctx_dir = tmp.path().join("contexts").join("doomed");
+    assert!(ctx_dir.exists(), "context dir should exist before destroy");
+
+    let (_, _, success) = run_chibi_json_with_home(
+        serde_json::json!({
+            "command": {"destroy_context": {"name": "doomed"}},
+            "context": "default"
+        }),
+        tmp.path(),
+    );
+    assert!(success, "destroy_context should succeed");
+    assert!(
+        !ctx_dir.exists(),
+        "context dir should be removed after destroy"
+    );
+}
+
+#[test]
+fn test_rename_context() {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    setup_context(tmp.path(), "oldname");
+
+    let (stdout, _, success) = run_chibi_json_with_home(
+        serde_json::json!({
+            "command": {"rename_context": {"old": "oldname", "new": "newname"}},
+            "context": "default"
+        }),
+        tmp.path(),
+    );
+    assert!(success, "rename_context should succeed");
+    assert!(
+        tmp.path().join("contexts").join("newname").exists(),
+        "new context dir should exist"
+    );
+    assert!(
+        !tmp.path().join("contexts").join("oldname").exists(),
+        "old context dir should be gone"
+    );
+    assert_valid_jsonl(&stdout);
+}
+
+#[test]
+fn test_show_log() {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    setup_context(tmp.path(), "logctx");
+
+    let (stdout, _, success) = run_chibi_json_with_home(
+        serde_json::json!({
+            "command": {"show_log": {"context": "logctx", "count": 0}},
+            "context": "default"
+        }),
+        tmp.path(),
+    );
+    assert!(success, "show_log should succeed");
+    // show_log in json mode emits raw TranscriptEntry JSON — content appears as a field value
+    assert!(
+        stdout.contains("hello"),
+        "should contain first entry content"
+    );
+    assert!(
+        stdout.contains("hi there"),
+        "should contain second entry content"
+    );
+    assert_valid_jsonl(&stdout);
+}
+
+#[test]
+fn test_show_log_empty() {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    // create context dir with empty transcript
+    let ctx_dir = tmp.path().join("contexts").join("empty");
+    std::fs::create_dir_all(&ctx_dir).expect("failed to create context dir");
+    std::fs::write(ctx_dir.join("context.jsonl"), "").expect("failed to write empty context");
+
+    let (stdout, _, success) = run_chibi_json_with_home(
+        serde_json::json!({
+            "command": {"show_log": {"context": "empty", "count": 0}},
+            "context": "default"
+        }),
+        tmp.path(),
+    );
+    assert!(success, "show_log on empty context should succeed");
+    // no entries means no stdout content lines (or only empty)
+    let content_lines: Vec<&str> = stdout.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(
+        content_lines.is_empty(),
+        "empty context should produce no output lines"
+    );
+}
+
+#[test]
+fn test_inspect_system_prompt() {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    setup_context(tmp.path(), "inspctx");
+    // write a system prompt file
+    let ctx_dir = tmp.path().join("contexts").join("inspctx");
+    std::fs::write(
+        ctx_dir.join("system_prompt.md"),
+        "you are a helpful assistant",
+    )
+    .expect("failed to write system prompt");
+
+    let (stdout, _, success) = run_chibi_json_with_home(
+        serde_json::json!({
+            "command": {"inspect": {"context": "inspctx", "thing": "system_prompt"}},
+            "context": "default"
+        }),
+        tmp.path(),
+    );
+    assert!(success, "inspect system_prompt should succeed");
+    assert!(
+        stdout.contains("you are a helpful assistant"),
+        "should show the system prompt content"
+    );
+    assert_valid_jsonl(&stdout);
+}
+
+#[test]
+fn test_set_system_prompt() {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    setup_context(tmp.path(), "setctx");
+
+    // set the prompt
+    let (_, _, success) = run_chibi_json_with_home(
+        serde_json::json!({
+            "command": {"set_system_prompt": {"context": "setctx", "prompt": "Be concise"}},
+            "context": "default"
+        }),
+        tmp.path(),
+    );
+    assert!(success, "set_system_prompt should succeed");
+
+    // verify via inspect
+    let (stdout, _, success) = run_chibi_json_with_home(
+        serde_json::json!({
+            "command": {"inspect": {"context": "setctx", "thing": "system_prompt"}},
+            "context": "default"
+        }),
+        tmp.path(),
+    );
+    assert!(success, "inspect after set should succeed");
+    assert!(
+        stdout.contains("Be concise"),
+        "inspect should show the prompt we set"
+    );
+}
+
+#[test]
+fn test_clear_cache() {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    setup_context(tmp.path(), "cachectx");
+
+    let (stdout, _, success) = run_chibi_json_with_home(
+        serde_json::json!({
+            "command": {"clear_cache": {"name": "cachectx"}},
+            "context": "default"
+        }),
+        tmp.path(),
+    );
+    assert!(
+        success,
+        "clear_cache should succeed on context without cache"
+    );
+    assert!(stdout.contains("Cleared"), "should confirm cache cleared");
+    assert_valid_jsonl(&stdout);
+}
+
+#[test]
+fn test_cleanup_cache() {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    setup_context(tmp.path(), "default");
+
+    let (stdout, _, success) = run_chibi_json_with_home(
+        serde_json::json!({"command": "cleanup_cache", "context": "default"}),
+        tmp.path(),
+    );
+    assert!(success, "cleanup_cache should succeed");
+    assert_valid_jsonl(&stdout);
+}
+
+#[test]
+fn test_noop() {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    setup_context(tmp.path(), "default");
+
+    let (stdout, _, success) = run_chibi_json_with_home(
+        serde_json::json!({"command": "no_op", "context": "default"}),
+        tmp.path(),
+    );
+    assert!(success, "no_op should succeed");
+    // no_op produces no output
+    let content_lines: Vec<&str> = stdout.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(content_lines.is_empty(), "no_op should produce no output");
+}
+
+#[test]
+fn test_archive_history() {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    setup_context(tmp.path(), "archctx");
+    let context_jsonl = tmp
+        .path()
+        .join("contexts")
+        .join("archctx")
+        .join("context.jsonl");
+    assert!(
+        !std::fs::read_to_string(&context_jsonl).unwrap().is_empty(),
+        "context should have entries before archive"
+    );
+
+    let (_, _, success) = run_chibi_json_with_home(
+        serde_json::json!({
+            "command": {"archive_history": {"name": "archctx"}},
+            "context": "default"
+        }),
+        tmp.path(),
+    );
+    assert!(success, "archive_history should succeed");
+    // archive_history calls clear_context which empties context.jsonl (the LLM window)
+    let content = std::fs::read_to_string(&context_jsonl).unwrap_or_default();
+    assert!(
+        content.trim().is_empty(),
+        "context.jsonl should be empty after archive, got: {}",
+        content
+    );
+}
+
+// === error path tests ===
+
+#[test]
+fn test_missing_command_field() {
+    let (stdout, _, success) = run_chibi_json(r#"{"context": "default"}"#);
+    assert!(!success, "missing command should fail");
+    assert_valid_jsonl(&stdout);
+    assert!(stdout.contains("error"), "should contain error type");
+}
+
+#[test]
+fn test_missing_context_field() {
+    let (stdout, _, success) = run_chibi_json(r#"{"command": "no_op"}"#);
+    assert!(!success, "missing context should fail");
+    assert_valid_jsonl(&stdout);
+    assert!(stdout.contains("error"), "should contain error type");
+}
+
+#[test]
+fn test_unknown_command_variant() {
+    let (stdout, _, success) =
+        run_chibi_json(r#"{"command": "nonexistent_thing", "context": "default"}"#);
+    assert!(!success, "unknown command should fail");
+    assert_valid_jsonl(&stdout);
+    assert!(stdout.contains("error"), "should contain error type");
+}
+
+// === JSONL format validation tests ===
+
+#[test]
+fn test_output_is_valid_jsonl() {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    let (stdout, _, success) = run_chibi_json_with_home(
+        serde_json::json!({"command": "list_contexts", "context": "default"}),
+        tmp.path(),
+    );
+    assert!(success);
+    assert_valid_jsonl(&stdout);
+}
+
+#[test]
+fn test_error_output_format() {
+    let (stdout, _, success) = run_chibi_json(r#"{"command": "bogus", "context": "x"}"#);
+    assert!(!success);
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("error output should be valid JSON");
+    assert_eq!(
+        parsed["type"], "error",
+        "error output should have type=error"
+    );
+    assert!(
+        parsed.get("message").is_some(),
+        "error output should have a message field"
+    );
+}
+
+#[test]
+fn test_result_output_format() {
+    let input = serde_json::json!({
+        "command": "show_version",
+        "context": "default"
+    });
+    let (stdout, _, success) = run_chibi_json(&input.to_string());
+    assert!(success);
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("result output should be valid JSON");
+    assert_eq!(
+        parsed["type"], "result",
+        "result output should have type=result"
+    );
+    assert!(
+        parsed.get("content").is_some(),
+        "result output should have a content field"
+    );
+    assert!(
+        parsed["content"].as_str().unwrap().contains("chibi-json"),
+        "version result should contain chibi-json"
+    );
 }


### PR DESCRIPTION
## Summary

closes #150

- **chibi-json**: 19 new integration tests covering command dispatch (list/destroy/rename/archive contexts, show_log, inspect, set_system_prompt, clear_cache, cleanup_cache, noop), error paths (missing command/context, unknown command), and JSONL format validation
- **chibi-core**: 14 new unit tests covering `Chibi` struct methods (init, shutdown, clear_context, list_contexts, resolve_config with local overrides, save, home_dir, tool_count, execute_tool for both not-found and builtin paths)
- added `create_test_chibi()` helper mirroring existing `create_test_app()` pattern
- added `run_chibi_json_with_home()`, `setup_context()`, `assert_valid_jsonl()` test helpers

## Test plan

- [x] `cargo test --lib -p chibi-core chibi::tests` — 25/25 pass
- [x] `cargo test -p chibi-json --test integration` — 24/24 pass
- [x] `just pre-push` — 815/815 tests pass, clippy + fmt clean