### PR TITLE
fix(compact): use char boundary for tool result preview truncation

### DIFF
--- a/crates/chibi-core/src/api/compact.rs
+++ b/crates/chibi-core/src/api/compact.rs
@@ -457,7 +457,8 @@ async fn compact_context_with_llm_internal(
         } else if role == "tool" {
             let content = m["content"].as_str().unwrap_or("");
             let preview = if content.len() > 200 {
-                format!("{}... [truncated]", &content[..200])
+                let end = content.char_indices().nth(200).map(|(i, _)| i).unwrap_or(content.len());
+                format!("{}... [truncated]", &content[..end])
             } else {
                 content.to_string()
             };


### PR DESCRIPTION
## Summary
- Fix panic in `compact.rs` when truncating tool result previews containing multi-byte UTF-8 characters (e.g. box-drawing chars like `└`)
- Use `char_indices().nth(200)` to find a safe char boundary instead of slicing raw bytes at offset 200

## Test plan
- [ ] Run `chibi -z` with a context containing multi-byte UTF-8 characters in tool results
- [ ] Verify no panic occurs at the truncation boundary